### PR TITLE
Updates from mdast to remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# MdastComponent
+# RemarkComponent
 
 **Render Markdown in React, in a component.**
 
-This uses [mdast-react](https://github.com/mapbox/mdast-react)
+This uses [remark-react](https://github.com/mapbox/remark-react)
 under the hood, so it **does not use dangerouslySetInnerHTML**, which means
 it doesn't do any innerHTML and has a smaller surface for security vulnerabilities
 than other approaches: its HTML output is guided by React's strict rules.
 
 ## Installation
 
-    npm install --save mdast-react-component
+    npm install --save remark-react-component
 
 ## Usage
 
 ```jsx
 var React = require('react'),
-    MdastComponent = require('mdast-react-component');
+    RemarkComponent = require('remark-react-component');
 
 var App = React.createClass({
     getInitialState() {
@@ -30,9 +30,9 @@ var App = React.createClass({
           value={this.state.text}
           onChange={this.onChange} />
         <div id='preview'>
-          <MdastComponent>
+          <RemarkComponent>
             {this.state.text}
-          </MdastComponent>
+          </RemarkComponent>
         </div>
       </div>);
     }

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 var React = require('react'),
-  mdast = require('mdast'),
-  reactRenderer = require('mdast-react');
+  remark = require('remark'),
+  reactRenderer = require('remark-react');
 
 /**
  * This component is wrapped around any part of a page.
  * When that part of the page is clicked, it selects
  * the text within.
  */
-var MdastComponent = React.createClass({
-  displayName: 'MdastComponent',
+var RemarkComponent = React.createClass({
+  displayName: 'RemarkComponent',
   propTypes: {
     children: React.PropTypes.any.isRequired
   },
   render: function() {
-    return mdast().use(reactRenderer).process(this.props.children);
+    return remark().use(reactRenderer).process(this.props.children);
   }
 });
 
-module.exports = MdastComponent;
+module.exports = RemarkComponent;

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "mdast-react-component",
+  "name": "remark-react-component",
   "version": "1.0.1",
-  "description": "compiles markdown to html using mdast-react as a component",
+  "description": "compiles markdown to html using remark-react as a component",
   "main": "index.js",
   "scripts": {
     "test": "tap test.js"
   },
   "keywords": [
-    "mdast",
+    "remark",
     "react",
     "component",
     "markdown"
@@ -15,8 +15,8 @@
   "author": "Tom MacWright",
   "license": "ISC",
   "dependencies": {
-    "mdast": "^1.1.0",
-    "mdast-react": "^0.1.1",
+    "remark": "^4.1.1",
+    "remark-react": "^2.0.0",
     "react": "^0.13.3"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 var test = require('tap').test,
   React = require('react/addons'),
-  MdastComponent = require('./');
+  RemarkComponent = require('./');
 
-test('MdastComponent', function(t) {
+test('RemarkComponent', function(t) {
   var renderer = React.addons.TestUtils.createRenderer();
-  var html = React.renderToStaticMarkup(React.createElement(MdastComponent, {}, '# Hello world\n\nhi [there](http://google.com/)'));
+  var html = React.renderToStaticMarkup(React.createElement(RemarkComponent, {}, '# Hello world\n\nhi [there](http://google.com/)'));
   t.equal(html, '<div><h1><span>Hello world</span></h1><p><span>hi </span><a href="http://google.com/"><span>there</span></a></p></div>');
   t.end();
 });


### PR DESCRIPTION
Remark-react was updated from mdast to remark in January 2016 in https://github.com/mapbox/remark-react/issues/13.

This PR updates mdast-react-component from mdast to remark.

/cc @tmcw 
